### PR TITLE
Break Kayfabe at the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## READ ME FIRST
+
+This project is presented as an example of how you'd develop a complete project in Julia. The rest of this README is written for an "imaginary user" of the complete project. If you are using this project, or its template, as an exercise in learning Julia, you should *ignore* this README, as you should work from the git repo you created.
+
 # HEPExampleProject.jl
 
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaHEP.github.io/HEPExampleProject.jl/stable/)


### PR DESCRIPTION
The README currently is written for a user who will "install the completed package" - but this confused some people doing the exercise, as they interpret is as instructions for them as _developers_
I added a bit to the top just to explain the context...