### PR TITLE
add formatting changes to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# update git config to use .git-blame-ignore-revs by default:
+# git config blame.ignoreRevsFile .git-blame-ignore-revs
+# or run manually with:
+# git blame --ignore-revs-file .git-blame-ignore-revs <file>
+#
+# fix formatting
+b353f80a172267484b4d0747b3bc7284a51f6582


### PR DESCRIPTION
Follow up to #10. 
Adding formatting to .git-blame-ignore-revs so they don't appear in the git blame. GitHub will recognize it [automatically](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view) local git might  not depending on the local config - instructions included in the file